### PR TITLE
Fix counter.inc(0) and counter.dec(0)

### DIFF
--- a/src/utils/probes/Counter.js
+++ b/src/utils/probes/Counter.js
@@ -12,11 +12,13 @@ Counter.prototype.val = function() {
 };
 
 Counter.prototype.inc = function(n) {
-  this._count += (n || 1);
+  const incBy = n == null ? 1 : n
+  this._count += incBy;
 };
 
 Counter.prototype.dec = function(n) {
-  this._count -= (n || 1);
+  const decBy = n == null ? 1 : n
+  this._count -= decBy;
 };
 
 Counter.prototype.reset = function(count) {

--- a/test/metric.mocha.js
+++ b/test/metric.mocha.js
@@ -58,3 +58,33 @@ describe('Metric', function() {
   })
 
 })
+
+describe('counter', () => {
+  describe('inc', () => {
+    const test = ({incBy, expectedValue}) => () => {
+      const counter = tx2.counter('Test counter')
+      counter.inc(incBy)
+      should(counter.val()).eql(expectedValue)
+    }
+
+    it('should increment by 1 when called with no arguments', test({expectedValue: 1}))
+    it('should increment by 1 when called with 1', test({incBy: 1, expectedValue: 1}))
+    it('should increment by -1 when called with -1', test({incBy: -1, expectedValue: -1}))
+    it('should increment by 0 when called with 0', test({incBy: 0, expectedValue: 0}))
+    it('should increment by 17.3 when called with 17.3', test({incBy: 17.3, expectedValue: 17.3}))
+  })
+
+  describe('dec', () => {
+    const test = ({decBy, expectedValue}) => () => {
+      const counter = tx2.counter('Test counter')
+      counter.dec(decBy)
+      should(counter.val()).eql(expectedValue)
+    }
+
+    it('should decrement by 1 when called with no arguments', test({expectedValue: -1}))
+    it('should decrement by 1 when called with 1', test({decBy: 1, expectedValue: -1}))
+    it('should decrement by -1 when called with -1', test({decBy: 1, expectedValue: -1}))
+    it('should decrement by 0 when called with 0', test({decBy: 0, expectedValue: 0}))
+    it('should decrement by 17.3 when called with 17.3', test({decBy: 17.3, expectedValue: -17.3}))
+  })
+})


### PR DESCRIPTION
Currently, attemtp to call `counter.inc(0)` and `counter.dec(0)` would increas and decrease counter value. That is an unfortunet bug when callind `.inc` or `.dec` with a variable that may have different values including zero e.g. `counter.inc(requests.length)`

With this PR, `counter.inc(0)` and `counter.dec(0)` would not change the value of the counter, just as expected

Tests that are failed with current behavior and are working with the fix are provided